### PR TITLE
Add tag set for logging with a set of keywords to filter on

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ To use it, add an entry in your timbre configuration `:appenders`:
 
 See [`taoensso.timbre.tools.logging`](http://ptaoussanis.github.io/timbre/taoensso.timbre.tools.logging.html).
 
+## Logging in Tests
+
+Sometimes it is useful to be able to modify log levels in tests.  We
+provide the `logging-threshold-fixture` function for use as a
+`clojure.test` fixture, and `suppress-logging` which provides a scope
+where all configured appenders are disabled.
+
 ## License
 
 Copyright © 2014 Hugo Duncan

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ value in the log message.
 There is also a `format-with-domain-context` that shows both domain
 and context values.
 
+## Tags for Filtering Log Messages
+
+To allow domain level filtering of log messages, use the `with-tags`
+macro, specifying a set of keywords.  The `tags-msg` timbre middleware
+adds this tag set on the `:tags` key.
+
 ## Add Log Message Key based on a Var
 
 The `add-var` function returns a timbre middleware to set a log

--- a/profiles.clj
+++ b/profiles.clj
@@ -1,6 +1,6 @@
 {:dev {:test-selectors {:default (complement :slf4j)
                         :slf4j :slf4j}
-       :plugins [[lein-pallet-release "0.1.3"]],
+       :plugins [[lein-pallet-release "0.1.4"]],
        :pallet-release
        {:url "https://pbors:${GH_TOKEN}@github.com/palletops/log-config.git",
         :branch "master"}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.palletops/log-config "0.1.1"
+(defproject com.palletops/log-config "0.1.2-SNAPSHOT"
   :description "Log appenders and middleware for timbre"
   :url "http://github.com/palletops/log-config"
   :license {:name "Eclipse Public License"

--- a/src/com/palletops/log_config/timbre.clj
+++ b/src/com/palletops/log_config/timbre.clj
@@ -91,15 +91,40 @@
           ns (or message "")
           (or (timbre/stacktrace throwable "\n" (when nofonts? {})) "")))
 
+;;; # Tags
+
+;;; Tags provide a set of keywords on which log messages can be filtered.  The
+;;; `tags-message` middleware is used to add them to the log message.
+
+(def ^:dynamic *tags* nil)
+
+(defmacro with-tags
+  "Set the tags for any log messages in body."
+  [tags & body]
+  `(binding [*tags* ~tags]
+     (assert (set? *tags*) "The tags must be a set of Named items.")
+     ~@body))
+
+(def tags-msg
+  "Add tags to log messages on the :tags key"
+  (add-var :tags #'*tags*))
+
 ;;; # Domain logging
 
-;;; Domain logging is not tied to namespaces.
+;;; Domain logging adds a keyword which is used as an alternative to
+;;; the namespace.
+
+;;; The `format-with-domain` timbre formatter will show the domain in
+;;; preference to the namespace.
+
 (def ^:dynamic *domain* nil)
 
 (defmacro with-domain
   "Set the domain for any log messages in body."
   [domain & body]
   `(binding [*domain* ~domain]
+     (assert (or (string? *domain*) (keyword? *domain*) (symbol? *domain*))
+             "The domain must be a string, keyword or symbol.")
      ~@body))
 
 (def domain-msg

--- a/test/com/palletops/log_config/timbre_test.clj
+++ b/test/com/palletops/log_config/timbre_test.clj
@@ -56,3 +56,17 @@
 (deftest with-context-update-test
   (with-context-update [[:x] (fnil conj []) :y]
     (is (= {:x [:y]} (context)))))
+
+(defn format-with-tags
+  [{:keys [tags]} & []]
+  (pr-str tags))
+
+(deftest tags-test
+  (testing "tags"
+    (is (= (str (pr-str #{:a :b}) \newline)
+           (with-out-str
+             (with-tags #{:a :b}
+               (log (merge example-config
+                           {:fmt-output-fn format-with-tags
+                            :middleware [tags-msg]})
+                    :info "something")))))))


### PR DESCRIPTION
Using a set of keywords would allow appenders to filter messages on multiple
domain concerns.
