### PR TITLE
Fix typo in suppress-logging macro

### DIFF
--- a/src/com/palletops/log_config/timbre.clj
+++ b/src/com/palletops/log_config/timbre.clj
@@ -178,7 +178,7 @@
   [& body]
   `(let [config# @timbre/config]
      (try
-       (doseq [appender# (:keys (:appenders config#))]
+       (doseq [appender# (keys (:appenders config#))]
          (timbre/set-config! [:appenders appender# :enabled?] false))
        ~@body
        (finally (timbre/merge-config! config#)))))


### PR DESCRIPTION
Looks like there's a typo in the suppress-logging macro which prevents it from ever working. Instead of calling the `(keys ...)` function, the keyword `:keys` is being used, which always returns nil. Bummer!
